### PR TITLE
Patching objToNavMesh to be more helpful

### DIFF
--- a/ObjReader.py
+++ b/ObjReader.py
@@ -41,7 +41,8 @@ USEMTL_PAT = re.compile('\s*usemtl\s+([a-zA-Z][a-zA-Z_0-9\(\)]*)')
 def getFaceData( data ):
     """Extracts vertex, normal and uv indices for a face definition.
         data consists of strings: i, i/i, i//i, or i/i/i.
-        All strings in the data should be of the same format. Format determines what inidices are defined"""
+        All strings in the data should be of the same format. Format determines what
+        indices are defined"""
     dataLists = [[], [], []]
     for s in data:
         indices = s.split('/')
@@ -361,7 +362,12 @@ class ObjFile:
         return s
     
     def readFile( self, filename ):
-        file = open( filename, 'r')
+        with open(filename, 'r') as file:
+            self.readFileLike(file)
+
+    def readFileLike(self, file):
+        '''Reads the obj data from the given file-like object. Must have the xreadlines()
+        method'''
         lineNum = 0
         for line in file.xreadlines():
             lineNum += 1

--- a/ObjReader.py
+++ b/ObjReader.py
@@ -344,6 +344,8 @@ class ObjFile:
         self.currGroup = None #self.groups['default']
         self.mtllib = None
         self.currMatName = 'default'
+        # A map from each vertex, normal, uv and face read and which line it was found.
+        self.object_line_numbers = {}
         if ( filename != None ):
             self.readFile( filename )
 
@@ -371,6 +373,7 @@ class ObjFile:
                 if ( match ):
                     try:
                         self.normSet.append(Vector3( match.group(1), match.group(2), match.group(3) ) )
+                        self.object_line_numbers[self.normSet[-1]] = lineNum
                     except:
                         raise IOError, "Expected vertex normal definition, line %d -- read: %s" % ( lineNum, line)
                 else:
@@ -380,6 +383,7 @@ class ObjFile:
                 if ( match ):
                     try:
                         self.uvSet.append(Vector2( match.group(1), match.group(2) ) )
+                        self.object_line_numbers[self.uvSet[-1]] = lineNum
                     except:
                         raise IOError, "Expected texture vertex definition, line %d -- read: %s" % ( lineNum, line)
                 else:
@@ -390,6 +394,7 @@ class ObjFile:
                     try:
                         v = Vector3( match.group(1), match.group(2), match.group(3) )
                         self.vertSet.append( v )
+                        self.object_line_numbers[v] = lineNum
                     except:
                         raise IOError, "Expected vertex definition, line %d -- read: %s" % ( lineNum, line)
                 else:
@@ -446,6 +451,7 @@ class ObjFile:
                     self.currGroup = Group( groupName )
                     self.groups[ groupName ] = self.currGroup
                 self.currGroup.addFace( f, self.currMatName )
+                self.object_line_numbers[f] = lineNum
             
 
     def writeOBJ( self, outfile ):

--- a/RoadContext.py
+++ b/RoadContext.py
@@ -575,7 +575,8 @@ class ObstacleContext( PGContext, MouseEnabled ):
                 '\n\t0            Do nothing' + \
                 '\n\t1            Create polygons' + \
                 '\n\t2            Edit polygons' + \
-                '\n\tCtrl+s       Save the obstacle file to "obstacles.xml"'
+                '\n\tCtrl+s       Save the obstacle file to "obstacles.xml"' + \
+                '\n\tShift+s      Save the obstacle file to "obstacles.obj"'
 
     NO_ACTION = 0
     NEW_POLY = 1
@@ -648,18 +649,26 @@ class ObstacleContext( PGContext, MouseEnabled ):
                         self.drawNormal = not self.drawNormal
                         self.obstacleSet.visibleNormals = self.drawNormal
                         result.set( True, True )
-                    elif ( self.obstacleSet and event.key == pygame.K_s and hasCtrl ):
-                        path = paths.getPath( 'obstacles.xml', False )
-                        print "Writing obstacles to:", path
-                        f = open( path, 'w' )
-                        f.write ('''<?xml version="1.0"?>
-<Experiment version="2.0">
+                    elif ( self.obstacleSet and event.key == pygame.K_s ):
+                        if hasCtrl and not hasShift and not hasAlt:
+                            path = paths.getPath( 'obstacles.xml', False )
+                            print "Writing obstacles to:", path
+                            f = open( path, 'w' )
+                            f.write ('''<?xml version="1.0"?>
+    <Experiment version="2.0">
 
-    <ObstacleSet type="explicit" class="1"> ''')
-                        f.write( '%s' % self.obstacleSet.xml() )
-                        f.write( '\n\t</ObstacleSet>\n\n</Experiment>' )
-                        f.close()
-                        result.set( True, False )
+        <ObstacleSet type="explicit" class="1"> ''')
+                            f.write( '%s' % self.obstacleSet.xml() )
+                            f.write( '\n\t</ObstacleSet>\n\n</Experiment>' )
+                            f.close()
+                            result.set( True, False )
+                        elif hasShift and not hasCtrl and not hasAlt:
+                            path = paths.getPath('obstacles.obj', False)
+                            print "Writing obj from obstacles to {}".format(path)
+                            with open(path, 'w') as f:
+                                f.write(self.obstacleSet.obj())
+                            result.set(True, False)
+
         return result    
 
     def handleMouse( self, event, view ):

--- a/objToNavMesh.py
+++ b/objToNavMesh.py
@@ -1,10 +1,84 @@
 # Parses an OBJ file and outputs an NavMesh file definition
 #   - see navMesh.py for the definition of that file format
 
+import sys
+
 from ObjReader import ObjFile
 from navMesh import Node, Edge, Obstacle, NavMesh
 import numpy as np
 from primitives import Vector2
+
+def analyze_obj(obj_file, vertex_tolerance=1e-4):
+    '''Analyzes the obj. It assess various aspects of the OBJ to determine if it is
+    sufficiently "clean" to have a navigation mesh. Some failed tests lead to warnings,
+    others lead to exit errors.
+    "Clean" means the following:
+
+    Error conditions:
+      - Adjacent faces must have consistent winding.
+      - There should be at *most* two faces adjacent to a single edge.
+      - T.B.D.
+
+    Warning conditions:
+      - Find out if there are any vertices within a user-given threshold
+        (This indicates the possibility of un-merged vertices).
+      - T.B.D.
+
+    @param obj_file           The parsed OBJ file to analyze.
+    @param vertex_tolerance   The minimum distance required between vertices.
+    '''
+    ## This determines if adjacent faces have reversed winding. We do this by looking at
+    ## how the edges are implicitly defined. The face (v0, v1, v2, v3) has edges
+    ## (v0, v1), (v1, v2), (v2, v3), and (v3, v0). Given the first edge, (v0, v1), if it
+    ## is shared by another face, that face should have it ordered as (v1, v0). This
+    ## represents consistent winding. If two faces refer to the same edge in the same
+    ## order, then they have inconsistent winding.
+    # A map from edge edge (v0, v1) to the face that referenced it.
+    edge_to_face = {}
+    # A map from unique edge identifier (a, b) to the faces that reference it.
+    # IN this case, it is guaranteed that a < b.
+    edge_count = {}
+    warnings = []
+    errors = []
+    for f_idx, (face, _) in enumerate(obj_file.getFaceIterator()):
+        v_count = len(face.verts)
+        for v_idx in xrange(-1, v_count - 1):
+            edge = (face.verts[v_idx], face.verts[v_idx + 1])
+            if edge in edge_to_face:
+                errors.append("The faces on lines {} and {} have inconsistent winding"
+                              .format(obj_file.object_line_numbers[face],
+                                      obj_file.object_line_numbers[edge_to_face[edge]]))
+            edge_to_face[edge] = face
+            unique_edge = (min(edge), max(edge))
+            edge_count[unique_edge] = edge_count.get(unique_edge, []) + [face]
+
+    bad_faces = filter(lambda face_list: len(face_list) > 2, edge_count.values())
+    for face_list in bad_faces:
+        errors.append("More than two faces reference the same edge. The faces on lines {}"
+                      .format(', '.join([str(obj_file.object_line_numbers[f]) for f in face_list])))
+
+    for i in xrange(len(obj_file.vertSet) - 1):
+        v_i = obj_file.vertSet[i]
+        for j in xrange(i + 1, len(obj_file.vertSet)):
+            v_j = obj_file.vertSet[j]
+            delta = (v_i - v_j).length()
+            if delta <= vertex_tolerance:
+                warnings.append("Vertices on lines {} and {} are closer ({} units) than "
+                                "the given tolerance {}"
+                                .format(obj_file.object_line_numbers[v_i],
+                                        obj_file.object_line_numbers[v_j],
+                                        delta,
+                                        vertex_tolerance))
+
+    if warnings:
+        print("The following issues were encountered which may indicate a problem:\n  {}"
+              .format("\n  ".join(warnings)))
+    if errors:
+        print("The following issues were encountered which prevent a navigation mesh "
+              "from being made from the given obj file:\n  {}"
+              .format("\n  ".join(errors)))
+        return False
+    return True
 
 def popEdge( e, vertMap, edges ):
     '''Removes the edge, e, from all references in the vertMap'''
@@ -194,11 +268,32 @@ def computeFacePlane(face, objFile):
         raise Exception("The face on line {} has insufficient vertices".format(objFile.object_line_numbers[face]))
     return n, d, mean_point
     
-def buildNavMesh( objFile ):
+def buildNavMesh(objFile, y_up):
     '''Given an ObjFile object, constructs the navigation mesh.writeNavFile
 
-    The node's will be grouped according to the obj face groups.
+    The nodes will be grouped according to the obj face groups.
+    @param  objFile     The parsed obj file with obj-style, 1-indexed vertex
+                        values.
+    @param  y_up        If True, <0, 1, 0> is the up vector and the 2D polygon
+                        is defined on the xz-plane with elevation as y(x, z). If False,
+                        <0, 0, 1> is the up vector and the 2D polygon is on the yz-plane
+                        with z(x, y).
     '''
+    if not analyze_obj(objFile):
+        sys.exit(1)
+
+    def extract_2d(v):
+        if y_up:
+            return v.x, v.z
+        else:
+            return v.x, v.y
+
+    def extract_up(v):
+        if y_up:
+            return v.y
+        else:
+            return v.z
+
     navMesh = NavMesh()
     V = objFile.vertSet
     navMesh.vertices = projectVertices( V )
@@ -206,7 +301,7 @@ def buildNavMesh( objFile ):
     edges = []
     # a dicitionary mapping an edge definition to the faces that are incident to it
     #   an "edge definition" is a two tuple of ints (a, b) such that:
-    #       a and b are indices to faces (qua nodes) AND
+    #       a and b are indices to *vertices* AND
     #       a < b
     edgeMap = {}
     nodes = []
@@ -220,20 +315,23 @@ def buildNavMesh( objFile ):
         A = B = C = 0.0
         M = []
         b = []
-        X = Z = 0.0
+        center_2d = Vector2(0, 0)
         vCount = len( face.verts )
         for v in xrange( vCount ):
             # build the matrix for this mesh
+
+            # NOTE: The obj file seems to be storing the obj, 1-indexed vertex value.
             vIdx = face.verts[ v ] - 1
             if ( not vertNodeMap.has_key( vIdx ) ):
                 vertNodeMap[ vIdx ] = [ node ]
             else:
                 vertNodeMap[ vIdx ].append( node )
             vert = V[ vIdx ]
-            X += vert.x
-            Z += vert.z
-            M.append( ( vert.x, vert.z, 1 ) )
-            b.append( vert.y )
+
+            x_2d, y_2d = extract_2d(vert)
+            center_2d += Vector2(x_2d, y_2d)
+            M.append((x_2d, y_2d, 1))
+            b.append(extract_up(vert))
             # define the edge
             nextIdx = face.verts[ ( v + 1 ) % vCount ] - 1
             edge = ( min( vIdx, nextIdx ), max( vIdx, nextIdx ) )
@@ -243,24 +341,29 @@ def buildNavMesh( objFile ):
                 raise AttributeError, "Edge %s has too many incident faces" % ( edge )
             else:
                 edgeMap[ edge ].append( (f,face) )
-            
-        node.center.x = X / vCount
-        node.center.y = Z / vCount
+        node.center = center_2d / vCount
         if ( vCount == 3 ):
             # solve explicitly
             try:
                 A, B, C = np.linalg.solve( M, b )
-            except np.linalg.linalg.LinAlgError as err:
-                print M, b
-                raise FloatingPointError("Face defined on line {} has a linear algebra error: {}".format(objFile.object_line_numbers[face], str(err)))
+            except np.linalg.linalg.LinAlgError:
+                raise ValueError("Face defined on line {} is too close to being co-linear"
+                                 .format(objFile.object_line_numbers[face]))
         else:
             # least squares
-            x, resid, rank, s = np.linalg.lstsq( M, b )
+            x, resid, rank, s = np.linalg.lstsq(M, b)
+            # TODO: Use rank and resid to confirm quality of answer:
+            #  rank will measure linear independence
+            #  resid will report planarity.
             A, B, C = x
+        # TODO: This isn't necessarily normalized. If b proves to be the zero vector, then
+        # I'm looking at the vector that is the nullspace of the matrix and that's true to
+        # arbitrary scale. Confirm that this isn't a problem.
         node.A = A
         node.B = B
         node.C = C
-        navMesh.addNode( node, grpName )
+        navMesh.addNode(node, grpName)
+
     print "Found %d edges" % ( len( edgeMap ) )
     edges = edgeMap.keys()
     internal = filter( lambda x: len( edgeMap[ x ] ) > 1, edges )
@@ -281,6 +384,9 @@ def buildNavMesh( objFile ):
         edge = Edge()
         edge.v0 = v0
         edge.v1 = v1
+        # TODO: Do these two nodes require a particular relationship vis a vis
+        # the vertex ordering? I.e., should a be on the left and b on the right?
+        # is that even guaranteed?
         edge.n0 = na
         edge.n1 = nb
         navMesh.addEdge( edge )
@@ -325,7 +431,7 @@ def buildNavMesh( objFile ):
     return navMesh
 
 def main():
-    import sys, os, optparse
+    import os, optparse
     parser = optparse.OptionParser()
     parser.set_description( 'Given an obj which defines a navigation mesh, this outputs '
                             'the corresponding navigation mesh file. The mesh must be '
@@ -334,9 +440,20 @@ def main():
                        action="store", dest="objFileName", default='' )
     parser.add_option( "-o", "--output", help="The name of the output file. The extension will automatically be added (.nav for ascii, .nbv for binary).",
                        action="store", dest="navFileName", default='output' )
+    parser.add_option('-u', '--up', dest='up', default='Y', action='store',
+                      help='The direction of the up vector -- should be either Y or Z')
 ##    parser.add_option( "-b", "--binary", help="Determines if the navigation mesh file is saved as a binary (by default, it saves an ascii file.",
 ##                       action="store_false", dest="outAscii", default=True )
     options, args = parser.parse_args()
+
+    y_up = True
+    if options.up.upper() in 'ZY':
+        y_up = options.up.upper() == 'Y'
+    else:
+        print("\nError: The up direction should be specified by either 'y' or 'z'. Found "
+              "{}\n'".format(options.up))
+        parser.print_help()
+        sys.exit(1)
 
     objFileName = options.objFileName
 
@@ -349,7 +466,7 @@ def main():
     gCount, fCount = obj.faceStats()
     print "\tFile has %d faces" % fCount
 
-    mesh = buildNavMesh( obj )
+    mesh = buildNavMesh(obj, y_up)
 
     outName = options.navFileName
 ##    ascii = options.outAscii

--- a/obstacles.py
+++ b/obstacles.py
@@ -118,6 +118,23 @@ class ObstacleSet:
         for p in self.polys:
             s += '\n{0}'.format( p.xml(2) )
         return s
+
+    def obj(self):
+        '''Returns an obj representation of the obstacle set'''
+        s = '# Computed by MengeUtils from xml specification' # TODO: Add date
+        vertices = []
+        for p in self.polys:
+            vertices += p.vertices
+        for v in vertices:
+            s += '\nv {} {} {}'.format(v.x, v.y, 0)
+        i = 1
+        for p in self.polys:
+            v_count = len(p.vertices)
+            v_indices = ' '.join(map(lambda x: str(x), xrange(i, i + v_count)))
+            s += '\nf {}'.format(v_indices)
+            i += v_count
+        s += '\n'
+        return s
     
     def __iter__( self ):
         return self.polys.__iter__()

--- a/primitives.py
+++ b/primitives.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 from struct import pack
 from math import sqrt
 
-class Vector2:
+class Vector2(object):
     def __init__(self, x, y):
         self.x = float(x)
         self.y = float(y)
@@ -101,7 +101,7 @@ class Vector2:
         self.x = -self.x
         self.y = -self.y
 
-class Vector3:
+class Vector3(object):
     def __init__( self, x, y, z ):
         self.x = float(x)
         self.y = float(y)
@@ -162,7 +162,6 @@ class Vector3:
         self.y += v.y
         self.z += v.z
         return self
-    
 
     def asTuple( self ):
         return (self.x, self.y, self.z)
@@ -213,7 +212,7 @@ class Vector3:
             dir = 2
         return dir
         
-class Face:
+class Face(object):
     def __init__( self, v = None, vn = None, vt = None ):
         if ( v == None ):
             self.verts = []

--- a/test/test_objToNavMesh.py
+++ b/test/test_objToNavMesh.py
@@ -1,0 +1,168 @@
+from contextlib import contextmanager
+import re
+from StringIO import StringIO
+import sys, os
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.relpath('..', os.path.dirname(__file__))))
+
+import objToNavMesh as dut
+import ObjReader
+
+
+@contextmanager
+def captured_output():
+    new_out, new_err = StringIO(), StringIO()
+    old_out, old_err = sys.stdout, sys.stderr
+    try:
+        sys.stdout, sys.stderr = new_out, new_err
+        yield sys.stdout, sys.stderr
+    finally:
+        sys.stdout, sys.stderr = old_out, old_err
+
+
+class FileBuffer:
+    '''Short-term hack to spoof file contents with in-memory buffer.
+    ObjReader.readFileLike() explicitly calls xreadlines(). It needs to be modernized.'''
+    def __init__(self, str_data):
+        self.str_data = str_data
+
+    def xreadlines(self):
+        return self.str_data.split('\n')
+
+
+class TestObjAnalysis(unittest.TestCase):
+    
+    def obj_from_string(self, obj_data):
+        '''Creates an ObjFile from a string containing an obj file's data'''
+        obj_file = FileBuffer(obj_data)
+        obj = ObjReader.ObjFile()
+        obj.readFileLike(obj_file)
+        return obj
+
+    def test_good_obj(self):
+        '''Analyzes trivially correct mesh'''
+        obj_data = '''v 0 0 0
+        v 1 0 0
+        v 1 1 0
+        v 0 1 0
+        f 4 3 1
+        f 2 1 3'''
+        obj = self.obj_from_string(obj_data)
+        self.assertTrue(dut.analyze_obj(obj))
+        
+    def test_bad_winding(self):
+        '''Tests that adjacent faces with inconsistent winding are detected.'''
+        # Creates the following simple mesh
+        #
+        #    v4    v3
+        #    o-----o
+        #    |->  /|
+        # f1 |   / |
+        #    |  /  | f2
+        #    | / ->|
+        #    o-----o
+        #    v1    v2
+        # Face 1 and face two have opposite winding
+        obj_data = '''v 0 0 0
+        v 1 0 0
+        v 1 1 0
+        v 0 1 0
+        f 4 3 1
+        f 1 2 3'''
+        obj = self.obj_from_string(obj_data)
+        with captured_output() as (out, err):
+            result = dut.analyze_obj(obj)
+            
+        self.assertFalse(result)
+        self.assertRegexpMatches(out.getvalue().strip(),
+                                 re.compile(".*prevent .* mesh from being made.*"
+                                            "The faces .* 6 .* 5 .* inconsistent winding",
+                                            re.DOTALL))
+
+    def test_too_many_faces(self):
+        '''Tests that a an edge with three adjacent faces is detected'''
+        # Reproduces the mesh in test_bad_winding, but adds an addition vertex *above* v3
+        # and a third face built on v1, v3, and v5.
+        
+        obj_data = '''v 0 0 0
+        v 1 0 0
+        v 1 1 0
+        v 0 1 0
+        v 1 1 1
+        f 4 3 1
+        f 1 2 3
+        f 1 3 5'''
+        obj = self.obj_from_string(obj_data)
+        with captured_output() as (out, err):
+            result = dut.analyze_obj(obj)
+            
+        self.assertFalse(result)
+        self.assertRegexpMatches(out.getvalue().strip(),
+                                 re.compile(".*prevent .* mesh from being made.*"
+                                            "More than two faces reference the same edge.*",
+                                            re.DOTALL))
+
+    def test_duplicate_vertices(self):
+        '''Tests the threshold for determining if vertices are too close.'''
+        # Obj data is the same as in test_bad_winding(), but with vertices 1 and 3
+        # literally duplicated.
+        obj_data = '''v 0 0 0
+        v 0 1 0
+        v 1 1 0
+        v 0 0 0
+        v 1 1 0
+        v 1 0 0
+        f 1 2 3
+        f 4 5 6'''
+        obj = self.obj_from_string(obj_data)
+        with captured_output() as (out, err):
+            # Duplicate is still caught with epsilon-sized tolerance.
+            result = dut.analyze_obj(obj, 1e-15)
+            
+        # Duplicate vertices don't cause failure; but they do spawn warnings.
+        self.assertTrue(result)
+        # NOTE: There should be *two* messages about duplicate vertices.
+        self.assertRegexpMatches(out.getvalue().strip(),
+                                 re.compile(".* which may indicate a problem.*"
+                                            "Vertices on lines .* are closer.*"
+                                            "Vertices on lines .* are closer.*",
+                                            re.DOTALL))
+
+    def test_vertices_too_close(self):
+        '''Tests the threshold for determining if vertices are too close.'''
+        # Obj data is the same as in test_bad_winding(), but with one vertex duplicated with
+        # a small perturbation.
+        deviation = 1e-7
+        obj_data = '''v {} 0 0
+        v 0 1 0
+        v 0 0 0
+        v 1 1 0
+        v 1 0 0
+        f 1 2 4
+        f 3 4 5'''.format(deviation)
+        obj = self.obj_from_string(obj_data)
+
+        # Case 1: tolerance is slightly *smaller* than the deviation.
+        with captured_output() as (out, err):
+            result = dut.analyze_obj(obj, deviation * 1.00001)
+
+        # Duplicate vertices don't cause failure; but they do spawn warnings.
+        self.assertTrue(result)
+        self.assertRegexpMatches(out.getvalue().strip(),
+                                 re.compile(".* which may indicate a problem.*"
+                                            "Vertices on lines .* are closer.*",
+                                            re.DOTALL))
+
+        # Case 1: tolerance is slightly *larger* than the deviation.
+        with captured_output() as (out, err):
+            result = dut.analyze_obj(obj, deviation * 0.9)
+
+        # Duplicate vertices don't cause failure; but they do spawn warnings.
+        self.assertTrue(result)
+        self.assertEquals(out.getvalue().strip(), "")
+        
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vField.py
+++ b/vField.py
@@ -296,6 +296,7 @@ class GLVectorField( VectorField ):
 
         Grid cells will ALWAYS be square.  The size of the domain will expand such that
         the dimensions of the span is an integer multiple of the cell size.'''
+        self.has_context = False
         VectorField.__init__( self, minPoint, size, cellSize )
         
         self.arrowID = 0    # the identifier for the arrow display list
@@ -310,12 +311,14 @@ class GLVectorField( VectorField ):
     def gridChanged( self ):
         '''Reports a change to the grid'''
         VectorField.gridChanged( self )
-        self.genArrowDL()
-        self.genGridDL()
+        if self.has_context:
+            self.genArrowDL()
+            self.genGridDL()
     
     def newGLContext( self ):
         '''When a new OpenGL context is created, this gives the field the chance to update
         its OpenGL objects'''
+        self.has_context = True
         self.genArrowDL()
         self.genGridDL()
 


### PR DESCRIPTION
Update objToNavMesh -- better feedback

This functionality has historically been brittle. It had a bunch of implicit assumptions that, if not met, led to inscrutable errors. This adds explicit integrity checks with meaningful error messages and unit tests on those integrity tests.

This also allows the user to specify which direction is "up". Previously, it was hard-coded to assume a y-up world. Now it can be specified on the command-line. This new functionality is *not* tested.
