### PR TITLE
Update objToNavMesh -- better feedback

### DIFF
--- a/ObjReader.py
+++ b/ObjReader.py
@@ -41,7 +41,8 @@ USEMTL_PAT = re.compile('\s*usemtl\s+([a-zA-Z][a-zA-Z_0-9\(\)]*)')
 def getFaceData( data ):
     """Extracts vertex, normal and uv indices for a face definition.
         data consists of strings: i, i/i, i//i, or i/i/i.
-        All strings in the data should be of the same format. Format determines what inidices are defined"""
+        All strings in the data should be of the same format. Format determines what
+        indices are defined"""
     dataLists = [[], [], []]
     for s in data:
         indices = s.split('/')
@@ -361,7 +362,12 @@ class ObjFile:
         return s
     
     def readFile( self, filename ):
-        file = open( filename, 'r')
+        with open(filename, 'r') as file:
+            self.readFileLike(file)
+
+    def readFileLike(self, file):
+        '''Reads the obj data from the given file-like object. Must have the xreadlines()
+        method'''
         lineNum = 0
         for line in file.xreadlines():
             lineNum += 1

--- a/objToNavMesh.py
+++ b/objToNavMesh.py
@@ -1,10 +1,89 @@
 # Parses an OBJ file and outputs an NavMesh file definition
 #   - see navMesh.py for the definition of that file format
 
+import sys
+
 from ObjReader import ObjFile
 from navMesh import Node, Edge, Obstacle, NavMesh
 import numpy as np
 from primitives import Vector2
+
+def analyze_obj(obj_file, vertex_tolerance=1e-4):
+    '''Analyzes the obj. It assess various aspects of the OBJ to determine if it is
+    sufficiently "clean" to have a navigation mesh. Some failed tests lead to warnings,
+    others lead to exit errors.
+    "Clean" means the following:
+
+    Error conditions:
+      - Adjacent faces must have consistent winding.
+      - There should be at *most* two faces adjacent to a single edge.
+      - T.B.D.
+
+    Warning conditions:
+      - Find out if there are any vertices within a user-given threshold
+        (This indicates the possibility of un-merged vertices).
+      - T.B.D.
+
+    @param obj_file           The parsed OBJ file to analyze.
+    @param vertex_tolerance   The minimum distance required between vertices.
+    '''
+    warnings = []
+    errors = []
+
+    ## This determines if adjacent faces have reversed winding. We do this by looking at
+    ## how the edges are implicitly defined. The face (v0, v1, v2, v3) has edges
+    ## (v0, v1), (v1, v2), (v2, v3), and (v3, v0). Given the first edge, (v0, v1), if it
+    ## is shared by another face, that face should have it ordered as (v1, v0). This
+    ## represents consistent winding. If two faces refer to the same edge in the same
+    ## order, then they have inconsistent winding.
+    # A map from edge edge (v0, v1) to the face that referenced it.
+    edge_to_face = {}
+    # A map from each unique edge identifier (a, b) to the faces that reference it.
+    # In this case, it is guaranteed that a < b.
+    unique_edges = {}
+    for face, _ in obj_file.getFaceIterator():
+        v_count = len(face.verts)
+        for v_idx in xrange(-1, v_count - 1):
+            edge = (face.verts[v_idx], face.verts[v_idx + 1])
+            if edge in edge_to_face:
+                errors.append("The faces on lines {} and {} have inconsistent winding"
+                              .format(obj_file.object_line_numbers[face],
+                                      obj_file.object_line_numbers[edge_to_face[edge]]))
+            edge_to_face[edge] = face
+            unique_edge = (min(edge), max(edge))
+            unique_edges[unique_edge] = unique_edges.get(unique_edge, []) + [face]
+
+    bad_faces = filter(lambda face_list: len(face_list) > 2, unique_edges.values())
+    for face_list in bad_faces:
+        errors.append("More than two faces reference the same edge. The faces on lines {}"
+                      .format(', '.join([str(obj_file.object_line_numbers[f])
+                                         for f in face_list])))
+
+    # Test for vertex distance against the given distance tolerance. Note: this is an
+    # O(N^2) operation. In the future, this *could* be accelerated as necessary.
+    for i in xrange(len(obj_file.vertSet) - 1):
+        v_i = obj_file.vertSet[i]
+        for j in xrange(i + 1, len(obj_file.vertSet)):
+            v_j = obj_file.vertSet[j]
+            delta = (v_i - v_j).length()
+            if delta <= vertex_tolerance:
+                warnings.append("Vertices on lines {} and {} are closer ({} units) than "
+                                "the given tolerance {}"
+                                .format(obj_file.object_line_numbers[v_i],
+                                        obj_file.object_line_numbers[v_j],
+                                        delta,
+                                        vertex_tolerance))
+
+    if warnings:
+        print("The following issues were encountered which may indicate a problem:\n  {}"
+              .format("\n  ".join(warnings)))
+
+    if errors:
+        print("The following issues were encountered which prevent a navigation mesh "
+              "from being made from the given obj file:\n  {}"
+              .format("\n  ".join(errors)))
+        return False
+    return True
 
 def popEdge( e, vertMap, edges ):
     '''Removes the edge, e, from all references in the vertMap'''
@@ -122,6 +201,7 @@ def startObstacle( vertMap, edges, obstacles ):
     obstacles.append( o )
     return o, e
 
+
 def processObstacles( obstacles, vertObstMap, vertNodeMap, navMesh ):
     '''Given a list of Obstacle instances, connects the obstacles into sequences such that each obstacle
     points to the appropriate "next" obstacle.  Assigns obstacles to nodes based on vertex.
@@ -150,63 +230,61 @@ def processObstacles( obstacles, vertObstMap, vertNodeMap, navMesh ):
 
     # all obstacles now have a "next" obstacle
     assert( len( filter( lambda x: x.next == -1, obstacles ) ) == 0 )
-        
-    navMesh.obstacles = obstacles
-    
 
-def projectVertices( vertexList ):
+    navMesh.obstacles = obstacles
+
+
+def projectVertices(vertexList, y_up):
     '''Given 3D vertices, projects them to 2D for the navigation mesh. Specifically,
-    projects them to the plane perpendicular to the y-axis.'''
+    projects them to a plane perpendicular to the y-axis (if y_up is True, otherwise uses
+    the z-axis).'''
     #TODO: Eventually the navigation mesh will require 3D data when it is no longer topologically planar
-    verts = map( lambda x: (x[0], x[2]), vertexList )
+    # The index of the 3D axis which maps to the 2d y-axis. Default to y-up (so we keep z.)
+    y_2d_axis = 2
+    if y_up == False:
+        # Z is up, so we keep the y-axis value.
+        y_2d_axis = 1
+    verts = map(lambda x: (x[0], x[y_2d_axis]), vertexList)
     return verts
 
-def computeFacePlane(face, objFile):
-    '''Given a face, calculates properties of the face:
-        The normal, n, the plane (Vector3)
-        the offset, d, of the plane (float), such that n.x + d = 0 for all vertices of the face, and
-        the mean vertex position, p.
-    We assume that face has counter-clockwise winding and is planar.'''
-    vCount = len(face.verts)
-    vertices = map(lambda v_idx: objFile.vertSet[v_idx], face.verts)
-    mean_point = reduce(lambda x, y: x + y, vertices) / float(vCount)
-    if (vCount == 3):
-        # Three vertices simply define a plane
-        a, b, c = vertices
-        u = b - a
-        v = c - a
-        n = u.cross(v)
-        n_mag = n.length()
-        if (n_mag < 1e-8):
-            raise Exception("The face on line {} has degenerate area".format(objFile.object_line_numbers[face]))
-        n /= n_mag
-        d = -n.dot(a)
-    elif (vCount > 3):
-        
-        M = np.ones((vCount, 4), dtype=np.float64)
-        b = np.zeros((vCount, 1), dtype=np.float64)
-        for r, v in enumerate(vertices):
-            M[r, :3] = (v.x, v.y, v.z)
-        x, resid, rank, s = np.linalg.lstsq( M, b )
-        A, B, C, d = x
-        n = Vector3(A, B, C)
-    else:
-        raise Exception("The face on line {} has insufficient vertices".format(objFile.object_line_numbers[face]))
-    return n, d, mean_point
-    
-def buildNavMesh( objFile ):
+
+def buildNavMesh(objFile, y_up, vertex_distance):
     '''Given an ObjFile object, constructs the navigation mesh.writeNavFile
 
-    The node's will be grouped according to the obj face groups.
+    The nodes will be grouped according to the obj face groups.
+    @param  objFile         The parsed obj file with obj-style, 1-indexed vertex
+                            values.
+    @param  y_up            If True, <0, 1, 0> is the up vector and the 2D polygon
+                            is defined on the xz-plane with elevation as y(x, z). If
+                            False, <0, 0, 1> is the up vector and the 2D polygon is on the
+                            yz-plane with z(x, y).
+    @param vertex_distance  A tolerance communicating a lower bound on the expected
+                            distances between all obj mesh vertices. If vertices are
+                            found this distance or nearer, a warning will be issued.
     '''
+    if not analyze_obj(objFile, vertex_distance):
+        sys.exit(1)
+
+    def extract_2d(v):
+        if y_up:
+            return v.x, v.z
+        else:
+            return v.x, v.y
+
+    def extract_up(v):
+        if y_up:
+            return v.y
+        else:
+            return v.z
+
     navMesh = NavMesh()
     V = objFile.vertSet
-    navMesh.vertices = projectVertices( V )
+    navMesh.vertices = projectVertices(V, y_up)
     vertNodeMap = {}    # maps a vertex index to all nodes that are incident to it
     edges = []
     # a dicitionary mapping an edge definition to the faces that are incident to it
     #   an "edge definition" is a two tuple of ints (a, b) such that:
-    #       a and b are indices to faces (qua nodes) AND
+    #       a and b are indices to *vertices* AND
     #       a < b
     edgeMap = {}
     nodes = []
@@ -220,20 +298,23 @@ def buildNavMesh( objFile ):
         A = B = C = 0.0
         M = []
         b = []
-        X = Z = 0.0
+        center_2d = Vector2(0, 0)
         vCount = len( face.verts )
         for v in xrange( vCount ):
             # build the matrix for this mesh
+
+            # NOTE: The obj file seems to be storing the obj, 1-indexed vertex value.
             vIdx = face.verts[ v ] - 1
             if ( not vertNodeMap.has_key( vIdx ) ):
                 vertNodeMap[ vIdx ] = [ node ]
             else:
                 vertNodeMap[ vIdx ].append( node )
             vert = V[ vIdx ]
-            X += vert.x
-            Z += vert.z
-            M.append( ( vert.x, vert.z, 1 ) )
-            b.append( vert.y )
+
+            x_2d, y_2d = extract_2d(vert)
+            center_2d += Vector2(x_2d, y_2d)
+            M.append((x_2d, y_2d, 1))
+            b.append(extract_up(vert))
             # define the edge
             nextIdx = face.verts[ ( v + 1 ) % vCount ] - 1
             edge = ( min( vIdx, nextIdx ), max( vIdx, nextIdx ) )
@@ -243,24 +324,29 @@ def buildNavMesh( objFile ):
                 raise AttributeError, "Edge %s has too many incident faces" % ( edge )
             else:
                 edgeMap[ edge ].append( (f,face) )
-            
-        node.center.x = X / vCount
-        node.center.y = Z / vCount
+        node.center = center_2d / vCount
         if ( vCount == 3 ):
             # solve explicitly
             try:
                 A, B, C = np.linalg.solve( M, b )
-            except np.linalg.linalg.LinAlgError as err:
-                print M, b
-                raise FloatingPointError("Face defined on line {} has a linear algebra error: {}".format(objFile.object_line_numbers[face], str(err)))
+            except np.linalg.linalg.LinAlgError:
+                raise ValueError("Face defined on line {} is too close to being co-linear"
+                                 .format(objFile.object_line_numbers[face]))
         else:
             # least squares
-            x, resid, rank, s = np.linalg.lstsq( M, b )
+            x, resid, rank, s = np.linalg.lstsq(M, b)
+            # TODO: Use rank and resid to confirm quality of answer:
+            #  rank will measure linear independence
+            #  resid will report planarity.
             A, B, C = x
+        # TODO: This isn't necessarily normalized. If b proves to be the zero vector, then
+        # I'm looking at the vector that is the nullspace of the matrix and that's true to
+        # arbitrary scale. Confirm that this isn't a problem.
         node.A = A
         node.B = B
         node.C = C
-        navMesh.addNode( node, grpName )
+        navMesh.addNode(node, grpName)
+
     print "Found %d edges" % ( len( edgeMap ) )
     edges = edgeMap.keys()
     internal = filter( lambda x: len( edgeMap[ x ] ) > 1, edges )
@@ -281,6 +367,9 @@ def buildNavMesh( objFile ):
         edge = Edge()
         edge.v0 = v0
         edge.v1 = v1
+        # TODO: Do these two nodes require a particular relationship vis a vis
+        # the vertex ordering? I.e., should a be on the left and b on the right?
+        # is that even guaranteed?
         edge.n0 = na
         edge.n1 = nb
         navMesh.addEdge( edge )
@@ -320,23 +409,44 @@ def buildNavMesh( objFile ):
     print "Found %d obstacles" % len( obstacles )
 ##    for o in obstacles:
 ##        print '\t', ' '.join( map( lambda x: str(x), o ) )
-    
-        
+
     return navMesh
 
 def main():
-    import sys, os, optparse
+    import os, optparse
     parser = optparse.OptionParser()
     parser.set_description( 'Given an obj which defines a navigation mesh, this outputs '
                             'the corresponding navigation mesh file. The mesh must be '
                             'defined in a y-up world.' )
-    parser.add_option( "-i", "--input", help="Name of obj file to convert",
-                       action="store", dest="objFileName", default='' )
-    parser.add_option( "-o", "--output", help="The name of the output file. The extension will automatically be added (.nav for ascii, .nbv for binary).",
-                       action="store", dest="navFileName", default='output' )
+    parser.add_option("-i", "--input", action="store", dest="objFileName", default='',
+                      help="Name of obj file to convert")
+    parser.add_option("-o", "--output", action="store", dest="navFileName",
+                      default='output', help="The name of the output file. The extension "
+                      "will automatically be added (.nav for ascii, .nbv for binary).")
+    parser.add_option('-u', '--up', dest='up', default='Y', action='store',
+                      help='The direction of the up vector -- should be either Y or Z')
+    parser.add_option('-d', '--distance', dest='vertex_distance', action='store',
+                      type=float, default=1e-5,
+                      help='Vertices are expected to be farther apart than this value. '
+                      'Must be a positive number.')
 ##    parser.add_option( "-b", "--binary", help="Determines if the navigation mesh file is saved as a binary (by default, it saves an ascii file.",
 ##                       action="store_false", dest="outAscii", default=True )
     options, args = parser.parse_args()
+
+    y_up = True
+    if options.up.upper() in 'ZY':
+        y_up = options.up.upper() == 'Y'
+    else:
+        print("\nError: The up direction should be specified by either 'y' or 'z'. Found "
+              "{}\n'".format(options.up))
+        parser.print_help()
+        sys.exit(1)
+
+    if options.vertex_distance <= 0.0:
+        print('\nError: The vertex distance value must be strictly positive. Found {}\n'
+              .format(options.vertex_distance))
+        parser.print_help()
+        sys.exit(1)
 
     objFileName = options.objFileName
 
@@ -349,7 +459,7 @@ def main():
     gCount, fCount = obj.faceStats()
     print "\tFile has %d faces" % fCount
 
-    mesh = buildNavMesh( obj )
+    mesh = buildNavMesh(obj, y_up, options.vertex_distance)
 
     outName = options.navFileName
 ##    ascii = options.outAscii

--- a/test/test_objToNavMesh.py
+++ b/test/test_objToNavMesh.py
@@ -1,0 +1,173 @@
+from contextlib import contextmanager
+import os
+import re
+from StringIO import StringIO
+import sys
+import unittest
+
+# This allows execution of this file, in this directory but gives it
+# access to the parent directory (the files under test).
+sys.path.insert(0, os.path.abspath(os.path.relpath('..', os.path.dirname(__file__))))
+
+import objToNavMesh as dut
+import ObjReader
+
+
+@contextmanager
+def captured_output():
+    '''Maps standard err and out to local memory buffers so broadcast messages
+    can be tested.'''
+    new_out, new_err = StringIO(), StringIO()
+    old_out, old_err = sys.stdout, sys.stderr
+    try:
+        sys.stdout, sys.stderr = new_out, new_err
+        yield sys.stdout, sys.stderr
+    finally:
+        sys.stdout, sys.stderr = old_out, old_err
+
+
+class FileBuffer:
+    '''Short-term hack to spoof file contents with in-memory buffer.
+    ObjReader.readFileLike() explicitly calls xreadlines(). It needs to be modernized.'''
+    def __init__(self, str_data):
+        self.str_data = str_data
+
+    def xreadlines(self):
+        return self.str_data.split('\n')
+
+
+class TestObjAnalysis(unittest.TestCase):
+
+    def obj_from_string(self, obj_data):
+        '''Creates an ObjFile from a string containing an obj file's data'''
+        obj_file = FileBuffer(obj_data)
+        obj = ObjReader.ObjFile()
+        obj.readFileLike(obj_file)
+        return obj
+
+    def test_good_obj(self):
+        '''Analyzes trivially correct mesh'''
+        obj_data = '''v 0 0 0
+        v 1 0 0
+        v 1 1 0
+        v 0 1 0
+        f 4 3 1
+        f 2 1 3'''
+        obj = self.obj_from_string(obj_data)
+        self.assertTrue(dut.analyze_obj(obj))
+
+    def test_bad_winding(self):
+        '''Tests that adjacent faces with inconsistent winding are detected.'''
+        # Creates the following simple mesh
+        #
+        #    v4    v3
+        #    o-----o
+        #    |->  /|
+        # f1 |   / |
+        #    |  /  | f2
+        #    | / ->|
+        #    o-----o
+        #    v1    v2
+        # Face 1 and face two have opposite winding
+        obj_data = '''v 0 0 0
+        v 1 0 0
+        v 1 1 0
+        v 0 1 0
+        f 4 3 1
+        f 1 2 3'''
+        obj = self.obj_from_string(obj_data)
+        with captured_output() as (out, err):
+            result = dut.analyze_obj(obj)
+
+        self.assertFalse(result)
+        self.assertRegexpMatches(out.getvalue().strip(),
+                                 re.compile(".*prevent .* mesh from being made.*"
+                                            "The faces .* 6 .* 5 .* inconsistent winding",
+                                            re.DOTALL))
+
+    def test_too_many_adjacent_faces(self):
+        '''Tests that a an edge with three adjacent faces is detected'''
+        # Reproduces the mesh in test_bad_winding, but adds an addition vertex *above* v3
+        # and a third face built on v1, v3, and v5.
+
+        obj_data = '''v 0 0 0
+        v 1 0 0
+        v 1 1 0
+        v 0 1 0
+        v 1 1 1
+        f 4 3 1
+        f 1 2 3
+        f 1 3 5'''
+        obj = self.obj_from_string(obj_data)
+        with captured_output() as (out, err):
+            result = dut.analyze_obj(obj)
+
+        self.assertFalse(result)
+        self.assertRegexpMatches(out.getvalue().strip(),
+                                 re.compile(".*prevent .* mesh from being made.*"
+                                            "More than two faces reference the same edge.*",
+                                            re.DOTALL))
+
+    def test_duplicate_vertices(self):
+        '''Tests that duplicate vertices get captured.'''
+        # Obj data is the same as in test_bad_winding(), but with vertices 1 and 3
+        # literally duplicated.
+        obj_data = '''v 0 0 0
+        v 0 1 0
+        v 1 1 0
+        v 0 0 0
+        v 1 1 0
+        v 1 0 0
+        f 1 2 3
+        f 4 5 6'''
+        obj = self.obj_from_string(obj_data)
+        with captured_output() as (out, err):
+            # Duplicate is still caught with epsilon-sized tolerance.
+            result = dut.analyze_obj(obj, 1e-15)
+
+        # Duplicate vertices don't cause failure; but they do spawn warnings.
+        self.assertTrue(result)
+        # NOTE: There should be *two* messages about duplicate vertices.
+        self.assertRegexpMatches(out.getvalue().strip(),
+                                 re.compile(".* which may indicate a problem.*"
+                                            "Vertices on lines .* are closer.*"
+                                            "Vertices on lines .* are closer.*",
+                                            re.DOTALL))
+
+    def test_vertices_too_close(self):
+        '''Tests the threshold for determining if vertices are too close.'''
+        # Obj data is the same as in test_bad_winding(), but with one vertex duplicated with
+        # a small perturbation.
+        deviation = 1e-7
+        obj_data = '''v {} 0 0
+        v 0 1 0
+        v 0 0 0
+        v 1 1 0
+        v 1 0 0
+        f 1 2 4
+        f 3 4 5'''.format(deviation)
+        obj = self.obj_from_string(obj_data)
+
+        # Case 1: tolerance is slightly *larger* than the deviation.
+        with captured_output() as (out, err):
+            result = dut.analyze_obj(obj, deviation * 1.00001)
+
+        # Duplicate vertices don't cause failure; but they do spawn warnings.
+        self.assertTrue(result)
+        self.assertRegexpMatches(out.getvalue().strip(),
+                                 re.compile(".* which may indicate a problem.*"
+                                            "Vertices on lines .* are closer.*",
+                                            re.DOTALL))
+
+        # Case 2: tolerance is slightly *smaller* than the deviation.
+        with captured_output() as (out, err):
+            result = dut.analyze_obj(obj, deviation * 0.999)
+
+        # Duplicate vertices don't cause failure; but they do spawn warnings.
+        self.assertTrue(result)
+        self.assertEquals(out.getvalue().strip(), "")
+
+# TODO: Test all of the other functionality in objToNavMesh.py.
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This functionality has historically been brittle. It had a bunch of implicit assumptions that, if not met, led to inscrutable errors. This adds explicit integrity checks with meaningful error messages and unit tests on those integrity tests.

This also allows the user to specify which direction is "up". Previously, it was hard-coded to assume a y-up world. Now it can be specified on the command-line. This new functionality is *not* tested.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/curds01/mengeutils/6)
<!-- Reviewable:end -->
