### PR TITLE
Fix scb context time scrubbing

### DIFF
--- a/docs/roadmap_builder.md
+++ b/docs/roadmap_builder.md
@@ -455,8 +455,7 @@ You can do the following to change the displayed frame:
 
   - Go to the first frame (`up arrow`).
   - Advance to the next frame (`right arrow`).
-  - Back up to the previous frame (`left arrow`). **This appears to have a bug. When in doubt,
-    reset to the first frame.**
+  - Back up to the previous frame (`left arrow`).
   - Advance or back up at a higher rate by holding down one or more modifier keys (`ctrl`, `alt`,
     and `shift`). The more keys you hold, the more frames are jumped with each press of the
    `right` and `left` arrow keys.


### PR DESCRIPTION
This fixes two errors in time scrubbing.

1. Scrubbing backwards at all crashed.
2. Bad condition seeking past the end of the file would cause crashes when
   scrubbing backwards.
3. Update documentation.

closes #11

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/curds01/mengeutils/12)
<!-- Reviewable:end -->
