### PR TITLE
Fix agent context -- deleting agents doesn't crash

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -224,15 +224,15 @@ class AgentSet:
 
     def deleteActiveAgent( self ):
         """Removes the active agent"""
-        if ( self.activeAgent ):
+        if self.activeAgent is not None:
             agt = self.activeAgent
             activeID = agt.id
-            Agent.ID -= 2
-            i = activeID >> 1
-            popped = self.agents.pop( i )
-            assert( popped == agt )
-            for a in self.agents[ i:]:
-                a.id -= 2
+            Agent.ID -= 1
+            popped = self.agents.pop(activeID)
+            assert(popped == agt)
+            # Decrement the ids of all agents following the active agent.
+            for a in self.agents[activeID:]:
+                a.id -= 1
             self.activeAgent = None
             return True
         return False

--- a/docs/roadmap_builder.md
+++ b/docs/roadmap_builder.md
@@ -292,10 +292,9 @@ be removed, or inserted into a selected edge. Whole polygons can be removed with
 ![An example of editing agents](images/roadmap_builder/agents_01.png)<br>
 **Figure 4: A number of agents added to the 4square example's obstacles.**
 
-The agent context allows for the addition and removal (see issue
-https://github.com/curds01/MengeUtils/issues/9) of agents. The agent radius can likewise be defined.
-Currently, no other agent properties can be configured. The agents defined in the application can be
-written to the `agents.xml` file in the output directory.
+The agent context allows for the addition and removal of agents. The agent radius can likewise be
+defined. Currently, no other agent properties can be configured. The agents defined in the
+application can be written to the `agents.xml` file in the output directory.
 
 ## Creating a navigation field
 


### PR DESCRIPTION
Now agents can be deleted properly. There was a left-over artifact from
when agents and per-agent goals were defined in tandem. I'd removed the
artifacts from a agent *adding* perspective, but I hadn't removed the
artifacts from deletion.

Resolves #9

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/curds01/mengeutils/13)
<!-- Reviewable:end -->
