### PR TITLE
RoadmapBuilder - Fix field smoothing

### DIFF
--- a/docs/roadmap_builder.md
+++ b/docs/roadmap_builder.md
@@ -397,8 +397,6 @@ hitting the `left` and `right` arrow keys.
 ![Smoothing the navigaiton field](images/roadmap_builder/field_4_smoothing.png)<br>
 **Figure 9: The navigation mesh in the smoothing mode.**
 
-**WARNING: This appears to be buggy in its current state!  Do not use!**
-
 Enter the field-smoothing modet by hitting the `3` key. The text `Brush smooth` will appear in
 the bottom-left corner and the cursor will change two be two concentric circles (a white and blue
 circle).
@@ -409,10 +407,17 @@ weights. The brush size (white circle) is changed with the `up` and `down` arrow
 
 The smoothing operation uses gaussian smoothing on the vector field. The size of the area considered
 is based on the kernel size (made larger and smaller with the `[` and `]` keys, respectively).
-Larger kernels has the effect of a larger "blur" operation. The smoothed field is combined with the
+Larger kernels have the effect of a larger "blur" operation. The smoothed field is combined with the
 existing field via the smoothing strength (made weaker and stronger with the `left` and `right`
-arrows, respectively). A small strength wil modify the field gradually. A large strength will
+arrows, respectively). A small strength will modify the field gradually. A large strength will
 modify the field at a higher rate.
+
+The "smoothing" simply linearly combines vector values. That means opposing vectors get gradually
+averaged to the zero vector; there is no spherical linear interpolation. Also, because of the
+nature of Gaussian smoothing, when applying smoothing near the boundary of the field, it must draw
+data from outside the domain of the field. In this case, it is provided with zero values. This has
+the effect of gradually smoothing the boundary vectors to zero. One way around this is to make the
+vector field larger than the region you care about.
 
 ## Playback SCB files
 

--- a/test/test_fieldTools.py
+++ b/test/test_fieldTools.py
@@ -1,0 +1,49 @@
+import os
+import sys
+import unittest
+
+# This allows execution of this file, in this directory but gives it
+# access to the parent directory (the files under test).
+sys.path.insert(0, os.path.abspath(os.path.relpath('..', os.path.dirname(__file__))))
+
+import fieldTools as dut
+from vField import VectorField
+
+class TestFieldTools(unittest.TestCase):
+
+    def test_smoothFieldRegionSize(self):
+        '''Tests the smoothFieldRegion() method; particularly that even as the region we want to
+        smooth gets near the boundary, we still get the region back.'''
+        # The *values* of the vector field don't matter. So, a simple grid [0, 0] X [10, 10] is
+        # sufficient.
+        field = VectorField((0,0), (10, 10), 1.0)
+        kernel_size = 1.0
+        minima = [4, 4]
+        maxima = [6, 6]
+        # confirm the region spans valid cells.
+        self.assertLessEqual(minima[0], field.data.shape[0])
+        self.assertLessEqual(maxima[0], field.data.shape[0])
+        self.assertLessEqual(minima[1], field.data.shape[1])
+        self.assertLessEqual(maxima[1], field.data.shape[1])
+        smoothed = dut.smoothFieldRegion(field, kernel_size, minima, maxima)
+        self.assertEqual(smoothed.shape[0], maxima[0] - minima[0])
+        self.assertEqual(smoothed.shape[1], maxima[1] - minima[1])
+
+        # This new region is the same size, but it moves the full work space off the domain of the
+        # field. It should still produce a result of the expected size. We know the kernel size
+        # will require data from outside the domain of the field (because the region lies on the
+        # boundary.
+        minima = [0, 0]
+        maxima = [2, 2]
+        # confirm the region spans valid cells.
+        self.assertLessEqual(minima[0], field.data.shape[0])
+        self.assertLessEqual(maxima[0], field.data.shape[0])
+        self.assertLessEqual(minima[1], field.data.shape[1])
+        self.assertLessEqual(maxima[1], field.data.shape[1])
+        smoothed = dut.smoothFieldRegion(field, kernel_size, minima, maxima)
+        self.assertEqual(smoothed.shape[0], maxima[0] - minima[0])
+        self.assertEqual(smoothed.shape[1], maxima[1] - minima[1])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_vField.py
+++ b/test/test_vField.py
@@ -1,0 +1,188 @@
+import os
+import sys
+import unittest
+
+import numpy as np
+
+# This allows execution of this file, in this directory but gives it
+# access to the parent directory (the files under test).
+sys.path.insert(0, os.path.abspath(os.path.relpath('..', os.path.dirname(__file__))))
+
+import vField as dut
+
+class TestVectorField(unittest.TestCase):
+
+    def make_field(self):
+        '''Creates the default vector field, storing the parameters that created it.'''
+        self.min_point = (0.0, -1.0)
+        self.size = (10.0, 9.0)
+        self.cell_size = 1.0
+        return dut.VectorField(self.min_point, self.size, self.cell_size)
+
+    def default_shape(self):
+        '''Reports the expected shape of the default vector field.'''
+        return (int(self.size[0]), int(self.size[1]), 2)
+
+    def test_Constructor(self):
+        field = self.make_field()
+        self.assertEqual(tuple(field.minPoint),  self.min_point)
+        self.assertEqual(field.cellSize,  self.cell_size)
+        # Note: this resolution works because I know cell size is 1.0.
+        self.assertEqual(tuple(field.resolution), self.size)
+        shape = self.default_shape()
+        self.assertEqual(field.data.shape, shape)
+        # The field is 2D vectors, so it's (w x h x 2)
+        self.assertEqual(field.data.size, 180)
+
+    def test_SetMinPoint(self):
+        field = self.make_field()
+
+        new_X = self.min_point[0] + 10.0
+        self.assertEqual(field.minPoint[0], self.min_point[0])
+        field.setMinX(new_X)
+        self.assertEqual(field.minPoint[0], new_X)
+
+        new_Y = self.min_point[1] + 10.0
+        self.assertEqual(field.minPoint[1], self.min_point[1])
+        field.setMinY(new_Y)
+        self.assertEqual(field.minPoint[1], new_Y)
+
+    def test_SetSize(self):
+        field = self.make_field()
+        orig_shape = self.default_shape()
+
+        new_W = self.size[1] * 2
+        self.assertEqual(field.data.shape[1], orig_shape[1])
+        field.setWidth(new_W)
+        self.assertEqual(field.data.shape[1], new_W)  # because cell size = 1.0
+
+        new_H = self.size[0] * 2
+        self.assertEqual(field.data.shape[0], orig_shape[0])
+        field.setHeight(new_H)
+        self.assertEqual(field.data.shape[0], new_H)  # because cell size = 1.0
+
+    def test_Corners(self):
+        field = self.make_field()
+        expected_corners = ((self.min_point[0], self.min_point[1]),
+                            (self.min_point[0] + self.size[1], self.min_point[1]),
+                            (self.min_point[0] + self.size[1], self.min_point[1] + self.size[0]),
+                            (self.min_point[0], self.min_point[1] + self.size[0]))
+        corners = field.getCorners()
+        for actual, expected in zip(corners, expected_corners):
+            self.assertEqual(tuple(actual), tuple(expected))
+
+    def test_subRegion(self):
+        '''Test the subregion access'''
+        field = self.make_field()
+        # populate the field; the x-value of each cell is equal to the cell center's position and
+        # similary the y-value.
+        data = np.empty_like(field.data)
+        min_center = np.array(self.min_point) + (self.cell_size * 0.5)
+        x_values = min_center[0] + np.arange(self.size[1])
+        y_values = min_center[1] + np.arange(self.size[0])
+        y_values.shape = (-1, 1)
+        data[:, :, 0] = x_values.T
+        data[:, :, 1] = y_values
+        self.assertEqual(tuple(data[3, 4, :]), (min_center[0] + 4, min_center[1] + 3))
+        field.data[:, :, :] = data
+
+        # Case: A single cell.
+        value = field.subRegion((3, 4), (4, 5))
+        self.assertEqual(value.size, 2) # simply two floats
+        self.assertEqual(tuple(value[0, 0, :]), (min_center[0] + 4, min_center[1] + 3))
+
+        # Case: A region of fully contained cells.
+        value = field.subRegion((3, 4), (5, 7))
+        self.assertEqual(value.size, 2 * 2 * 3)  # a 2x3 region of two floats each
+        for r in xrange(2):
+            global_r = 3 + r
+            for c in xrange(3):
+                global_c = 4 + c
+                expected_value = (min_center[0] + global_c, min_center[1] + global_r)
+                self.assertEqual(tuple(value[r, c, :]), expected_value)
+        # TODO(curds01): when it is completely contained, I should have a slice into the data and
+        # should be able to edit it directly; test this.
+
+        # Case: region extends beyond boundary (in negative direction)
+        value = field.subRegion((-1, -2), (2, 3))
+        self.assertEqual(value.size, 3 * 5 * 2)
+        for r in xrange(3):
+            global_r = -1 + r
+            for c in xrange(5):
+                global_c = -2 + c
+                expected_value = [0, 0]
+                if field.isValidCell(global_r, global_c):
+                    expected_value = (min_center[0] + global_c, min_center[1] + global_r)
+                self.assertEqual(tuple(value[r, c, :]), tuple(expected_value))
+
+        # Case: region extends beyond boundary (in positive direction)
+        max_r = int(self.size[0] - 1)
+        max_c = int(self.size[1] - 1)
+        value = field.subRegion((max_r - 1, max_c - 2), (max_r + 2, max_c + 3))
+        self.assertEqual(value.size, 3 * 5 * 2)
+        for r in xrange(3):
+            global_r = max_r - 1 + r
+            for c in xrange(5):
+                global_c = max_c - 2 + c
+                expected_value = [0, 0]
+                if field.isValidCell(global_r, global_c):
+                    expected_value = (min_center[0] + global_c, min_center[1] + global_r)
+                self.assertEqual(tuple(value[r, c, :]), tuple(expected_value))
+
+        # Case: region lies completely outside of the field; negative direction.
+        value = field.subRegion((-6,-3), (-3, -2))
+        self.assertEqual(value.size, 3 * 1 * 2)
+        for r in xrange(3):
+            for c in xrange(1):
+                expected_value = (0, 0)
+                self.assertEqual(tuple(value[r, c, :]), expected_value)
+
+        # Case: region lies completely outside of the field; positive direction.
+        value = field.subRegion((max_r + 2, max_c + 3), (max_r + 4, max_c + 4))
+        self.assertEqual(value.size, 2 * 1 * 2)
+        for r in xrange(2):
+            for c in xrange(1):
+                expected_value = (0, 0)
+                self.assertEqual(tuple(value[r, c, :]), expected_value)
+
+        # Case: region lies completely outside of the field; mixed directions.
+        value = field.subRegion((-4, max_c + 3), (-1, max_c + 5))
+        self.assertEqual(value.size, 3 * 2 * 2)
+        for r in xrange(3):
+            for c in xrange(2):
+                expected_value = (0, 0)
+                self.assertEqual(tuple(value[r, c, :]), expected_value)
+
+        # Case: region is larger all around.
+        value = field.subRegion((-2, -3), (max_r + 2, max_c + 3))
+        self.assertEqual(value.size, (max_r + 4) * (max_c + 6) * 2)
+        for r in xrange(max_r + 4):
+            global_r = -2 + r
+            for c in xrange(max_c + 6):
+                global_c = -3 + c
+                expected_value = [0, 0]
+                if field.isValidCell(global_r, global_c):
+                    expected_value = (min_center[0] + global_c, min_center[1] + global_r)
+                self.assertEqual(tuple(value[r, c, :]), tuple(expected_value))
+
+
+    # TODO(curds01): Test the following:
+    #  - setCellSize()
+    #  - setDimensions()
+    #  - getCell()
+    #  - getCells()
+    #  - getMagnitudes()
+    #  - cellCenters()
+    #  - cellSegmentDistance()
+    #  - cellDistances()
+    #  - fieldChanged()
+    #  - write()
+    #  - gridChange()
+    #  - writeAscii()
+    #  - read()
+    #  - readAscii()
+    #  - readBinary()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vField.py
+++ b/vField.py
@@ -27,6 +27,10 @@ class VectorField:
         self.cellSize = cellSize
         self.setDimensions( size )
 
+    def isValidCell(self, r, c):
+        '''Reports True if (r, c) references a valid cell in the data'''
+        return r >= 0 and c >= 0 and r < self.data.shape[0] and c < self.data.shape[1]
+
     def setMinX( self, value ):
         '''Sets the minimum x-value'''
         self.minPoint[0] = value
@@ -125,18 +129,53 @@ class VectorField:
                         vector in cell[n,m].
         '''
         return np.sqrt( np.sum( self.data * self.data, 2 ) )
-    
-    def subRegion( self, minima, maxima ):
-        '''Returns a portion of the field, defined by the index minima and maxima.
 
-        @param minima: a 2-tuple-like object of ints.  The indices (i, j) represent the smallest indices of
-        the region to compute.
-        @param maxima: a 2-tuple-like object of ints.  The indices (I, J) represent the largest indices of the
-        region to compute.  The region is defined as field[ i:I, j:J ].
+    def subRegion( self, minima, maxima ):
+        '''Returns a portion of the field, defined by the index minima and maxima. The region is
+        defined in the range [minima, maxima) -- in other words, the cell indices in maxima define
+        the cells that the region goes up to, but does not include.
+
+        If the sub region extends beyond the domain of the field, the "extra" cells will be
+        populated with the zero value. The resulting region will be a unique, deep copy of the data.
+        However, if the region is completely contained by the field, it will be a mutable slice
+        into the data.
+
+        @param minima:      A 2-tuple-like object of ints. The indices (i, j) represent the smallest
+                            indices of the region to compute.
+        @param maxima:      A 2-tuple-like object of ints. The indices (I, J) represent the largest
+                            indices of the region to compute. The region is defined as
+                            `field[i:I, j:J]`.
 
         @return: a (I-i) x (J-j) x 2 array of floats.  The sub-region of the field.
+
+        @pre The maxima index values must be at least as large as the minima index values.
         '''
-        return self.data[ minima[0]:maxima[0], minima[1]:maxima[1], : ]
+        assert(maxima[0] >= minima[0])
+        assert(maxima[1] >= minima[1])
+        if (minima[0] >= 0 and minima[1] >= 0 and
+            maxima[0] < self.data.shape[0] and maxima[1] < self.data.shape[1]):
+            return self.data[minima[0]:maxima[0], minima[1]:maxima[1], :]
+        row_count = maxima[0] - minima[0]
+        col_count = maxima[1] - minima[1]
+        result = np.zeros((row_count, col_count, 2), dtype=self.data.dtype)
+        # Compute the region to read from and the corresponding region to write to.
+        min_r = max(0, minima[0])
+        min_c = max(0, minima[1])
+        # Note: min(shape[i], maxima[i]) can produce a value that's *less* than minima.
+        # Specifically, it can produce a negative value. If min slice index is non-negative and the
+        # max slice index is negative and valid (i.e., in the range [-1, -self.shape[i]]), then I'll
+        # get a valid, non-empty slice. So, in this case, we confirm that the slice is logically
+        # meaningful before we turn it over to numpy to slice.
+        max_r = max(min(self.data.shape[0], maxima[0]), min_r)
+        max_c = max(min(self.data.shape[1], maxima[1]), min_c)
+        sub_region = self.data[min_r:max_r:1, min_c:max_c:1, :]
+        if sub_region.size > 0:
+            delta_r = max_r - min_r
+            delta_c = max_c - min_c
+            target_r = min_r - minima[0]
+            target_c = min_c - minima[1]
+            result[target_r:target_r + delta_r, target_c:target_c + delta_c, :] = sub_region
+        return result
 
     def cellCenters( self, minima, maxima ):
         '''Returns the cell centers for a range of cell fields defined by index minima and maxima.


### PR DESCRIPTION
This fixes a bug with field smoothing; when the smoothing brush got too close to the field boundary, it would crash. Too close is defined by brush size and kernel size. It would have to draw data from a region that may have extended beyond the field.

This modifies the VectorField.subRegion() method to return empty fields when accessing regions beyond the valid domains (as represented by cell indices). That means the smoothing will include lots of zeros near the boundary.

This also introduces some rudimentary unit tests for both vector field and field tools. There is still a *ton* to unit test.

Closes #14

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/curds01/mengeutils/15)
<!-- Reviewable:end -->
